### PR TITLE
Update path in prep for on demand

### DIFF
--- a/aks/update-image.sh
+++ b/aks/update-image.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Check if ACR name is provided
+if [ -z "$1" ]; then
+    echo "Usage: $0 <acr_name>"
+    exit 1
+fi
+
+acr_name="$1"
+
+# Update the image line in each deployment file
+for file in amd64-deployment.yaml arm64-deployment.yaml multi-arch-deployment.yaml; do
+    if [ -f "$file" ]; then
+        sed -i.bak "s|<your deployed ACR name>|${acr_name}|g" "$file"
+        rm "${file}.bak"  # Clean up backup file
+        echo "Updated $file"
+    else
+        echo "Warning: $file not found. Skipping."
+    fi
+done
+
+echo "ACR updates completed."

--- a/instruqt/aks.md
+++ b/instruqt/aks.md
@@ -25,9 +25,7 @@ All three of these files are very similar. They deploy our application from the 
 
 `multi-arch-deployment.yaml` deploys the application to run on whatever node is available. However `arm64-deployment.yaml` and `amd64-deployment.yaml` implement an additional two lines of yaml called a `nodeSelector`, that only allows our application to run on either `arm64` or `amd64` based nodes respectively.
 
-In each file, we will need to update it to point to our ACR we were using in the previous steps.
-
-Change line 21 of all three files from:
+In each file, we will need to update line 21 of all three files to point to our ACR we were using in the previous steps:
 
 ```yaml
         image: <your deployed ACR name>.azurecr.io/multi-arch:latest
@@ -42,7 +40,15 @@ to
 > [!NOTE]
 > Note the name of your deployed Azure Container Registry, if it is not the default `armacr[[ Instruqt-Var key="randomid" hostname="cloud-client" ]]` then edit the above line.
 
-Once the files are saved, we are ready to deploy our application on our AKS cluster.
+In order make things easier, we are provided a simple script `update-image.sh` to do this for you. Simply run the following command:
+
+```yaml
+./update-image.sh armacr[[ Instruqt-Var key="randomid" hostname="cloud-client" ]]
+```
+
+You can confirm the lines were changed correctly by looking at the files in the editor tab.
+
+Once the files are updated, we are ready to deploy our application on our AKS cluster.
 
 ## Deploy initial AKS workload
 ===

--- a/instruqt/aks.md
+++ b/instruqt/aks.md
@@ -42,7 +42,7 @@ to
 
 In order make things easier, we are provided a simple script `update-image.sh` to do this for you. Simply run the following command:
 
-```yaml
+```bash,run
 ./update-image.sh armacr[[ Instruqt-Var key="randomid" hostname="cloud-client" ]]
 ```
 

--- a/instruqt/check-deploy.sh
+++ b/instruqt/check-deploy.sh
@@ -59,3 +59,38 @@ for resource in "${EXPECTED_RESOURCES[@]}"; do
         fail-message "Not all required resources were found in the Azure subscription: $resource_type '$resource_name' is missing."
     fi
 done
+
+# Check AKS cluster status
+echo "Checking AKS cluster provisioning state..."
+AKS_STATE=$(az aks show --name "${EXPECTED_RESOURCES[1]#*:}" --resource-group "${EXPECTED_RESOURCES[0]#*:}" --subscription "$SUBSCRIPTION_ID" --query "provisioningState" -o tsv)
+if [ "$AKS_STATE" != "Succeeded" ]; then
+    echo "❌ AKS cluster deployment failed. Current state: $AKS_STATE"
+    fail-message "AKS cluster deployment was not successful. Current state: $AKS_STATE"
+else
+    echo "✅ AKS cluster deployment successful."
+fi
+
+# Check ACR status
+echo "Checking ACR provisioning state..."
+ACR_STATE=$(az acr show --name "${EXPECTED_RESOURCES[2]#*:}" --subscription "$SUBSCRIPTION_ID" --query "provisioningState" -o tsv)
+if [ "$ACR_STATE" != "Succeeded" ]; then
+    echo "❌ ACR deployment failed. Current state: $ACR_STATE"
+    fail-message "ACR deployment was not successful. Current state: $ACR_STATE"
+else
+    echo "✅ ACR deployment successful."
+fi
+
+# Check node pools status
+for i in {3..4}; do
+    nodepool_name="${EXPECTED_RESOURCES[$i]#*:}"
+    echo "Checking node pool '$nodepool_name' provisioning state..."
+    NODEPOOL_STATE=$(az aks nodepool show --cluster-name "${EXPECTED_RESOURCES[1]#*:}" --resource-group "${EXPECTED_RESOURCES[0]#*:}" --name "$nodepool_name" --subscription "$SUBSCRIPTION_ID" --query "provisioningState" -o tsv)
+    if [ "$NODEPOOL_STATE" != "Succeeded" ]; then
+        echo "❌ Node pool '$nodepool_name' deployment failed. Current state: $NODEPOOL_STATE"
+        fail-message "Node pool '$nodepool_name' deployment was not successful. Current state: $NODEPOOL_STATE"
+    else
+        echo "✅ Node pool '$nodepool_name' deployment successful."
+    fi
+done
+
+echo "✅ All deployments completed successfully!"

--- a/instruqt/setup.sh
+++ b/instruqt/setup.sh
@@ -42,6 +42,64 @@ done
 echo "Logged in using service principal. Using Azure location: $location"
 
 ###############################################################################
+# Create Azure Policy to restrict VMSS SKUs
+###############################################################################
+echo "Creating Azure policy to restrict VMSS SKUs..."
+
+# Create policy definition
+policy_rule='{
+  "if": {
+    "allOf": [
+    {
+      "field": "type",
+      "equals": "Microsoft.Compute/virtualMachineScaleSets"
+    },
+    {
+      "not": {
+      "field": "Microsoft.Compute/virtualMachineScaleSets/sku.name",
+      "in": "[parameters('\''multiarchAllowedSKUs'\'')]"
+      }
+    }
+    ]
+  },
+  "then": {
+    "effect": "Deny"
+  }
+}'
+az policy definition create \
+  --name "restrict-vmss-skus" \
+  --display-name "Restrict Virtual Machine Scale Sets SKUs" \
+  --description "Restricts VMSS to only use allowed SKUs for multiarch workshop" \
+  --mode "Indexed" \
+  --rules "$policy_rule" \
+  --params '{
+  "multiarchAllowedSKUs": {
+    "type": "Array",
+    "metadata": {
+    "displayName": "Allowed Size SKUs",
+    "description": "The list of size SKUs that can be specified for VMSS.",
+    "strongType": "VMSKUs"
+    }
+  }
+}'
+
+# Assign policy to subscription
+az policy assignment create \
+  --name "restrict-vmss-skus-assignment" \
+  --display-name "Restrict VMSS SKUs Assignment" \
+  --policy "restrict-vmss-skus" \
+  --params '{
+    "multiarchAllowedSKUs": {
+      "value": [
+        "standard_b2pls_v2",
+        "standard_a2_v2"
+      ]
+    }
+  }'
+
+echo "Azure policy created and assigned successfully."
+
+###############################################################################
 # Clone Git repo
 ###############################################################################
 git clone https://github.com/ArmDeveloperEcosystem/workshop-multiarch-aks.git multiarch

--- a/instruqt/solve-deploy.sh
+++ b/instruqt/solve-deploy.sh
@@ -1,21 +1,18 @@
 #!/bin/bash
 set -euxo pipefail
 
-# Function to print error messages
-error_exit() {
-    echo "❌ ERROR: $1" >&2
-    exit 1
-}
+echo "Starting deploy solve script"
 
-cd terraform || error_exit "Failed to change directory to terraform."
+cd multiarch/terraform
 
-terraform init -input=false || error_exit "Terraform init failed."
+terraform init -input=false
 
 terraform plan -var="subscription_id=$(az account show --query id --output tsv)" -var="random_id=$(agent variable get randomid)" -out tfplan
 
 echo "🚀 Applying Terraform changes..."
-if terraform apply tfplan -auto-approve; then
+if terraform apply tfplan; then
     echo "✅ Terraform apply completed successfully."
 else
-    error_exit "Terraform apply failed."
+    echo "❌ Terraform apply failed."
+    exit 1
 fi

--- a/instruqt/solve-deploy.sh
+++ b/instruqt/solve-deploy.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Function to print error messages
+error_exit() {
+    echo "❌ ERROR: $1" >&2
+    exit 1
+}
+
+cd terraform || error_exit "Failed to change directory to terraform."
+
+terraform init -input=false || error_exit "Terraform init failed."
+
+terraform plan -var="subscription_id=$(az account show --query id --output tsv)" -var="random_id=$(agent variable get randomid)" -out tfplan
+
+echo "🚀 Applying Terraform changes..."
+if terraform apply tfplan -auto-approve; then
+    echo "✅ Terraform apply completed successfully."
+else
+    error_exit "Terraform apply failed."
+fi

--- a/instruqt/solve-import.sh
+++ b/instruqt/solve-import.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euxo pipefail
+
+echo "🚀 Importing image into Azure Container Registry..."
+az acr import --name armacr$(agent variable get randomid) --source docker.io/avinzarlez979/multi-arch:latest --image multi-arch:latest
+echo "✅ ACR image import completed successfully."

--- a/terraform/aks.tf
+++ b/terraform/aks.tf
@@ -9,7 +9,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
   }
   default_node_pool {
     name       = "armpool"
-    vm_size    = "standard_d2ps_v5" # To change to: standard_b2pls_v2
+    vm_size    = "standard_b2pls_v2"
     node_count = var.agent_count
   }
   identity {

--- a/terraform/aks.tf
+++ b/terraform/aks.tf
@@ -9,7 +9,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
   }
   default_node_pool {
     name       = "armpool"
-    vm_size    = "Standard_D2ps_v6"
+    vm_size    = "standard_d2ps_v5" # To change to: standard_b2pls_v2
     node_count = var.agent_count
   }
   identity {
@@ -20,7 +20,7 @@ resource "azurerm_kubernetes_cluster" "k8s" {
 resource "azurerm_kubernetes_cluster_node_pool" "amdcluster" {
   name                  = "amdpool"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.k8s.id
-  vm_size               = "Standard_D2as_v5"
+  vm_size               = "standard_a2_v2"
   node_count            = var.agent_count
 
   tags = {


### PR DESCRIPTION
Updated workshop to prepare for on demand


This pull request introduces several improvements and new scripts to streamline the AKS deployment workflow, automate image updates in deployment files, and enhance Azure resource validation and policy enforcement. The changes focus on automation, correctness, and compliance with workshop requirements.

**Automation and Workflow Improvements**

* Added a new script `aks/update-image.sh` to automatically update the image registry reference in all deployment YAML files, replacing manual editing steps.
* Updated documentation in `instruqt/aks.md` to instruct users to use `update-image.sh` for updating deployment files, simplifying the workflow and reducing manual errors. [[1]](diffhunk://#diff-8faa193277e16929a1775944a8e9f7beff1e816f5cbab472adf8a2de7ec794beL28-R28) [[2]](diffhunk://#diff-8faa193277e16929a1775944a8e9f7beff1e816f5cbab472adf8a2de7ec794beL45-R51)
* Added `instruqt/solve-deploy.sh` and `instruqt/solve-import.sh` scripts to automate Terraform deployment and ACR image import steps, respectively. [[1]](diffhunk://#diff-17af6250261c684e5377d30ffdcd3adf7042b2d4ca3d2ad78565c1930c87a893R1-R18) [[2]](diffhunk://#diff-1c6d2b2cffc14ce065c20da1fc64529da60d38c3fc1fc16ae01409f93ca184fcR1-R6)

**Azure Policy Enforcement**

* Enhanced `instruqt/setup.sh` to create and assign Azure policies that restrict allowed VMSS SKUs and prevent standalone VM deployments outside AKS node pools, ensuring compliance with lab requirements.

**Resource Validation and Configuration**

* Improved `instruqt/check-deploy.sh` to check the provisioning state of AKS clusters, ACR, and node pools, providing clear feedback and error handling for deployment validation.
* Updated Terraform AKS node pool VM sizes in `terraform/aks.tf` to use allowed SKUs (`standard_b2pls_v2` for ARM and `standard_a2_v2` for AMD), aligning infrastructure with new policy restrictions. [[1]](diffhunk://#diff-d859ee67be7945b668865badbd1c2bea32ddc74f0ae1b4ed8fb96b0e8696a549L12-R12) [[2]](diffhunk://#diff-d859ee67be7945b668865badbd1c2bea32ddc74f0ae1b4ed8fb96b0e8696a549L23-R23)